### PR TITLE
fix: eliminate high-severity silent failures (PR 2/3)

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -145,6 +145,7 @@ def read_task_counts(project_path: Path) -> dict:
 
         # If we got any GitHub data, return it
         if any(counts.values()):
+            counts["source"] = "github"
             return counts
     except Exception as e:
         import logging
@@ -156,13 +157,17 @@ def read_task_counts(project_path: Path) -> dict:
     # Fallback to local task files
     tasks_dir = project_path / ".agent" / "tasks"
     if not tasks_dir.exists():
+        counts["source"] = "local_fallback"
         return counts
     for task_file in tasks_dir.glob("task-*.md"):
         content = task_file.read_text()
         for status in counts:
+            if status == "source":
+                continue
             if f"status: {status}" in content:
                 counts[status] += 1
                 break
+    counts["source"] = "local_fallback"
     return counts
 
 
@@ -536,6 +541,13 @@ def trigger_orchestrator(name: str):
             start_new_session=True,
         )
 
+    # Verify the process actually started
+    if process.poll() is not None and process.returncode != 0:
+        raise HTTPException(
+            status_code=500,
+            detail=f"forge-run.sh failed to start (exit code {process.returncode}). Check {log_file}",
+        )
+
     return {"status": "started", "name": name, "pid": process.pid, "open_issues": open_issues, "log": str(log_file)}
 
 
@@ -560,6 +572,13 @@ def trigger_planner(name: str):
             stdout=f,
             stderr=subprocess.STDOUT,
             start_new_session=True,
+        )
+
+    # Verify the process actually started
+    if process.poll() is not None and process.returncode != 0:
+        raise HTTPException(
+            status_code=500,
+            detail=f"forge-plan.sh failed to start (exit code {process.returncode}). Check {log_file}",
         )
 
     return {"status": "started", "name": name, "pid": process.pid, "log": str(log_file)}
@@ -593,6 +612,13 @@ def prd_to_issues(name: str, req: PrdToIssuesRequest):
             stdout=f,
             stderr=subprocess.STDOUT,
             start_new_session=True,
+        )
+
+    # Verify the process actually started
+    if process.poll() is not None and process.returncode != 0:
+        raise HTTPException(
+            status_code=500,
+            detail=f"forge-prd-to-issues.sh failed to start (exit code {process.returncode}). Check {log_file}",
         )
 
     return {"status": "started", "name": name, "pid": process.pid, "log": str(log_file)}
@@ -695,36 +721,34 @@ async def deploy_project(name: str, req: DeployRequest):
             ["git", "rev-parse", "--verify", "staging"],
             cwd=str(project_path),
             capture_output=True,
+            text=True,
         )
 
-        if staging_check.returncode == 0:
-            # Merge staging into main
-            subprocess.run(["git", "checkout", "main"], cwd=str(project_path), capture_output=True)
-            merge_result = subprocess.run(
-                ["git", "merge", "staging", "--no-edit", "-m", "promote: staging → main"],
-                cwd=str(project_path),
-                capture_output=True,
-                text=True,
+        if staging_check.returncode != 0:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Staging branch does not exist in {name}. Cannot promote to production without a staging branch.",
             )
-            if merge_result.returncode != 0:
-                raise HTTPException(
-                    status_code=500,
-                    detail=f"Merge staging→main failed: {merge_result.stderr}",
-                )
-            # Push main to remote
-            subprocess.run(
-                ["git", "push", "origin", "main"],
-                cwd=str(project_path),
-                capture_output=True,
+
+        # Merge staging into main
+        subprocess.run(["git", "checkout", "main"], cwd=str(project_path), capture_output=True)
+        merge_result = subprocess.run(
+            ["git", "merge", "staging", "--no-edit", "-m", "promote: staging → main"],
+            cwd=str(project_path),
+            capture_output=True,
+            text=True,
+        )
+        if merge_result.returncode != 0:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Merge staging→main failed: {merge_result.stderr}",
             )
-        else:
-            # No staging branch — just pull main
-            subprocess.run(
-                ["git", "pull", "origin", "main"],
-                cwd=str(project_path),
-                capture_output=True,
-                text=True,
-            )
+        # Push main to remote
+        subprocess.run(
+            ["git", "push", "origin", "main"],
+            cwd=str(project_path),
+            capture_output=True,
+        )
 
         # Call docker-ops to rebuild
         async with httpx.AsyncClient(timeout=300) as client:

--- a/bot/handlers/conversations.py
+++ b/bot/handlers/conversations.py
@@ -308,8 +308,8 @@ def _create_github_issue(project_path: str, title: str, body: str, labels: list[
         return None
 
 
-def _get_open_issues(project_path: str) -> list[dict]:
-    """Get open GitHub Issues for dedup checking."""
+def _get_open_issues(project_path: str) -> list[dict] | None:
+    """Get open GitHub Issues for dedup checking. Returns None on failure (dedup unavailable)."""
     try:
         result = subprocess.run(
             ["gh", "issue", "list", "--state", "open", "--json", "number,title", "--limit", "50"],
@@ -324,9 +324,10 @@ def _get_open_issues(project_path: str) -> list[dict]:
         )
         if result.returncode == 0:
             return json.loads(result.stdout)
+        logger.error(f"_get_open_issues: gh returned exit code {result.returncode}: {result.stderr.strip()}")
     except Exception as e:
-        logger.warning(f"_get_open_issues: gh command failed: {e}")
-    return []
+        logger.error(f"_get_open_issues: gh command failed: {e}")
+    return None
 
 
 def _comment_on_issue(project_path: str, issue_number: int, comment: str) -> bool:

--- a/scripts/forge-cleanup.sh
+++ b/scripts/forge-cleanup.sh
@@ -66,7 +66,7 @@ cleanup_orphaned_branches() {
         if ! echo "$open_issues" | grep -q "^$issue_num$"; then
             # Issue is closed, remove the branch
             echo "  Pruning closed issue branch: $branch"
-            git push origin -d "$branch" 2>/dev/null || true
+            git push origin -d "$branch" 2>&1 || echo "WARNING: failed to delete remote branch $branch" >&2
             deleted=$((deleted + 1))
         fi
     done
@@ -76,7 +76,7 @@ cleanup_orphaned_branches() {
         local issue_num="${branch#issue/}"
         if ! echo "$open_issues" | grep -q "^$issue_num$"; then
             echo "  Deleting local closed issue branch: $branch"
-            git branch -D "$branch" 2>/dev/null || true
+            git branch -D "$branch" 2>&1 || echo "WARNING: failed to delete local branch $branch" >&2
         fi
     done
 

--- a/scripts/forge-deploy.sh
+++ b/scripts/forge-deploy.sh
@@ -102,7 +102,8 @@ if [[ "$ACTION" == "teardown" ]]; then
     if [[ -f "$STAGING_COMPOSE" ]]; then
         cd "$PROJECT_PATH"
         if ! docker compose -f docker-compose.staging.yml down -v 2>&1; then
-            echo "ERROR: docker compose down failed. Containers may still be running." >&2
+            echo "ERROR: docker compose down failed. Stale containers may still be running and interfere with future deploys." >&2
+            echo "Run 'docker ps' to check for orphaned containers." >&2
         fi
     fi
 
@@ -189,8 +190,11 @@ fi
 
 # --- Tear down existing staging if running ---
 echo "Stopping existing staging (if any)..."
+STALE_CONTAINERS=false
 if ! docker compose -f docker-compose.staging.yml down -v 2>&1; then
-    echo "WARNING: docker compose down failed — old containers may still be running" >&2
+    echo "WARNING: docker compose down failed — stale containers may interfere with new deploy" >&2
+    echo "Check 'docker ps' for orphaned containers if the new deploy fails." >&2
+    STALE_CONTAINERS=true
 fi
 
 # --- Build and start staging from staging branch ---
@@ -205,6 +209,14 @@ git pull origin staging 2>&1
 
 docker compose -f docker-compose.staging.yml build 2>&1
 docker compose -f docker-compose.staging.yml up -d 2>&1
+
+# Verify the new deploy actually started
+if ! docker compose -f docker-compose.staging.yml ps --status running 2>/dev/null | grep -q .; then
+    echo "ERROR: New staging containers are not running after deploy." >&2
+    if $STALE_CONTAINERS; then
+        echo "ERROR: This may be caused by stale containers from the failed teardown." >&2
+    fi
+fi
 
 # Switch back to original branch
 git checkout "$CURRENT_BRANCH" 2>&1

--- a/scripts/forge-run.sh
+++ b/scripts/forge-run.sh
@@ -34,6 +34,7 @@ notify_event() {
         echo "## $(date -u +%Y-%m-%dT%H:%M:%SZ) | NOTIFICATION_FAILURE" >> "$PROJECT_PATH/.agent/ERRORS.md"
         echo "**Event that failed to send:** $*" >> "$PROJECT_PATH/.agent/ERRORS.md"
         echo "" >> "$PROJECT_PATH/.agent/ERRORS.md"
+        return 1
     fi
 }
 
@@ -46,6 +47,7 @@ gh_label() {
         echo "## $(date -u +%Y-%m-%dT%H:%M:%SZ) | GH_LABEL_FAILURE" >> "$PROJECT_PATH/.agent/ERRORS.md"
         echo "**Failed command:** gh issue edit #$issue $*" >> "$PROJECT_PATH/.agent/ERRORS.md"
         echo "" >> "$PROJECT_PATH/.agent/ERRORS.md"
+        return 1
     fi
 }
 
@@ -206,7 +208,7 @@ for branch in $(git branch -r 2>/dev/null | grep "origin/issue/" | sed 's|.*/||'
     issue_num="${branch#issue/}"
     if ! echo "$open_issues" | grep -q "^$issue_num$"; then
         echo "    Pruning closed issue branch: $branch"
-        git push origin -d "$branch" 2>/dev/null || true
+        git push origin -d "$branch" 2>&1 || echo "WARNING: failed to delete remote branch $branch" >&2
     fi
 done
 
@@ -214,7 +216,7 @@ for branch in $(git branch 2>/dev/null | grep "issue/" | sed 's/^[* ] //' | xarg
     issue_num="${branch#issue/}"
     if ! echo "$open_issues" | grep -q "^$issue_num$"; then
         echo "    Deleting local closed issue branch: $branch"
-        git branch -D "$branch" 2>/dev/null || true
+        git branch -D "$branch" 2>&1 || echo "WARNING: failed to delete local branch $branch" >&2
     fi
 done
 
@@ -256,7 +258,7 @@ while true; do
         for branch in $remote_branches; do
             issue_num="${branch#issue/}"
             if ! echo "$open_issues" | grep -q "^$issue_num$"; then
-                git push origin -d "$branch" 2>/dev/null || true
+                git push origin -d "$branch" 2>&1 || echo "WARNING: failed to delete remote branch $branch" >&2
             fi
         done
     fi

--- a/scripts/forge-worker.sh
+++ b/scripts/forge-worker.sh
@@ -37,7 +37,9 @@ cleanup_worktree() {
     cd "$PROJECT_PATH" 2>/dev/null || true
     if [[ -d "$WORKTREE_DIR" ]]; then
         if ! git worktree remove "$WORKTREE_DIR" --force 2>/dev/null; then
-            rm -rf "$WORKTREE_DIR" 2>/dev/null || true
+            if ! rm -rf "$WORKTREE_DIR" 2>/dev/null; then
+                echo "ERROR: cleanup trap failed to remove worktree $WORKTREE_DIR" >&2
+            fi
         fi
     fi
 }
@@ -188,7 +190,8 @@ if $COMMITTED; then
     cd "$WORKTREE_DIR"
 
     git push origin "$BRANCH_NAME" --force-with-lease 2>&1 || {
-        echo "Warning: Could not push to remote."
+        echo "ERROR: Could not push to remote. PR creation requires a pushed branch." >&2
+        exit 1
     }
 
     # Check if an OPEN PR already exists for this branch (ignore closed/merged)
@@ -302,7 +305,7 @@ Closes #$ISSUE_NUMBER"
                     echo "Closing issue #$ISSUE_NUMBER..."
                     cd "$PROJECT_PATH"
                     if ! gh issue close "$ISSUE_NUMBER" 2>&1; then
-                        echo "WARNING: Could not close issue #$ISSUE_NUMBER" >&2
+                        echo "ERROR: Could not close issue #$ISSUE_NUMBER — issue will remain open and may be re-picked by the pipeline" >&2
                     fi
                 else
                     echo "ERROR: Auto-merge failed for PR #$PR_NUMBER" >&2
@@ -347,8 +350,11 @@ else
     echo "  git worktree remove failed, attempting force cleanup..." >&2
     # If git removal fails, force-delete the directory
     if [[ -d "$WORKTREE_DIR" ]]; then
-        rm -rf "$WORKTREE_DIR"
-        echo "  Worktree directory forcefully removed."
+        if rm -rf "$WORKTREE_DIR"; then
+            echo "  Worktree directory forcefully removed."
+        else
+            echo "ERROR: rm -rf failed on worktree $WORKTREE_DIR — stale worktree may block future workers" >&2
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Summary

- **Shell scripts**: `notify_event()` and `gh_label()` now propagate failure (return 1). Branch deletion `|| true` abuse replaced with logged warnings. `forge-worker` exits on push failure instead of creating PR against missing branch. Worktree cleanup logs errors instead of swallowing them.
- **forge-deploy**: docker compose down failure warns about stale containers. Post-deploy verification checks containers are actually running.
- **API**: `read_task_counts()` reports data source ("github" vs "local_fallback"). Three Popen calls verify process started. Missing staging branch raises 400 instead of silently continuing.
- **Bot**: `_get_open_issues()` returns None on failure (was `[]`) so callers know dedup is unavailable instead of silently creating duplicate issues.

## Test plan

- [ ] Run `forge run omnilingo` — verify orchestrator starts and logs show source field
- [ ] Kill forge-api, run `/board` — verify error surfaced
- [ ] Run `forge-worker.sh` with network down — verify push failure exits cleanly
- [ ] Run `forge deploy omnilingo` — verify post-deploy health check

🤖 Generated with [Claude Code](https://claude.com/claude-code)