### PR TITLE
fix: eliminate medium-severity silent failures (PR 3/3)

### DIFF
--- a/agents/orchestrator/AGENT.md
+++ b/agents/orchestrator/AGENT.md
@@ -4,6 +4,12 @@
 **Model:** Opus
 **Role:** Ralph Loop task orchestrator — plans, routes, manages merge queue
 
+## Error Handling — Mandatory
+- NEVER suppress errors silently. If a subprocess, API call, or file operation fails, surface it immediately.
+- Log all errors to .agent/ERRORS.md AND report to the user/orchestrator.
+- If using a fallback, log a WARNING that the primary path failed.
+- A loud failure that gets fixed is always better than a silent one that rots.
+
 ---
 
 ## Core Loop (Ralph Loop)

--- a/agents/planner-critic/AGENT.md
+++ b/agents/planner-critic/AGENT.md
@@ -4,6 +4,12 @@
 **Model:** Sonnet
 **Role:** Adversarial plan reviewer — catches what the Orchestrator missed
 
+## Error Handling — Mandatory
+- NEVER suppress errors silently. If a subprocess, API call, or file operation fails, surface it immediately.
+- Log all errors to .agent/ERRORS.md AND report to the user/orchestrator.
+- If using a fallback, log a WARNING that the primary path failed.
+- A loud failure that gets fixed is always better than a silent one that rots.
+
 ---
 
 ## When You Run

--- a/agents/pm/AGENT.md
+++ b/agents/pm/AGENT.md
@@ -4,6 +4,12 @@
 **Model:** Sonnet
 **Role:** Human-facing project manager — intake interviews, status reports, feature requests
 
+## Error Handling — Mandatory
+- NEVER suppress errors silently. If a subprocess, API call, or file operation fails, surface it immediately.
+- Log all errors to .agent/ERRORS.md AND report to the user/orchestrator.
+- If using a fallback, log a WARNING that the primary path failed.
+- A loud failure that gets fixed is always better than a silent one that rots.
+
 ---
 
 ## Hard Rules

--- a/agents/reviewer/AGENT.md
+++ b/agents/reviewer/AGENT.md
@@ -4,6 +4,12 @@
 **Model:** Sonnet
 **Role:** Code review, quality scoring, error pattern detection, model fit assessment
 
+## Error Handling — Mandatory
+- NEVER suppress errors silently. If a subprocess, API call, or file operation fails, surface it immediately.
+- Log all errors to .agent/ERRORS.md AND report to the user/orchestrator.
+- If using a fallback, log a WARNING that the primary path failed.
+- A loud failure that gets fixed is always better than a silent one that rots.
+
 ---
 
 ## Review Protocol

--- a/agents/security/AGENT.md
+++ b/agents/security/AGENT.md
@@ -4,6 +4,12 @@
 **Model:** Sonnet
 **Role:** Two-layer security gate — deterministic tools + /security-review skill
 
+## Error Handling — Mandatory
+- NEVER suppress errors silently. If a subprocess, API call, or file operation fails, surface it immediately.
+- Log all errors to .agent/ERRORS.md AND report to the user/orchestrator.
+- If using a fallback, log a WARNING that the primary path failed.
+- A loud failure that gets fixed is always better than a silent one that rots.
+
 ---
 
 ## When You Run

--- a/agents/ui-designer/AGENT.md
+++ b/agents/ui-designer/AGENT.md
@@ -4,6 +4,12 @@
 **Model:** Opus
 **Role:** Translates functional spec into UI spec. Only activated for frontend projects.
 
+## Error Handling — Mandatory
+- NEVER suppress errors silently. If a subprocess, API call, or file operation fails, surface it immediately.
+- Log all errors to .agent/ERRORS.md AND report to the user/orchestrator.
+- If using a fallback, log a WARNING that the primary path failed.
+- A loud failure that gets fixed is always better than a silent one that rots.
+
 ---
 
 ## When You Run

--- a/agents/worker/AGENT.md
+++ b/agents/worker/AGENT.md
@@ -4,6 +4,12 @@
 **Model:** Haiku / Sonnet / Opus (assigned per task complexity)
 **Role:** Implement a single task in an isolated git worktree
 
+## Error Handling — Mandatory
+- NEVER suppress errors silently. If a subprocess, API call, or file operation fails, surface it immediately.
+- Log all errors to .agent/ERRORS.md AND report to the user/orchestrator.
+- If using a fallback, log a WARNING that the primary path failed.
+- A loud failure that gets fixed is always better than a silent one that rots.
+
 ---
 
 ## Startup Protocol (Follow This Exactly)

--- a/api/api.py
+++ b/api/api.py
@@ -1,6 +1,7 @@
 """forge-api — Project registry and orchestrator trigger for the forge pipeline."""
 
 import json
+import logging
 import os
 import subprocess
 from datetime import datetime, timezone
@@ -9,6 +10,8 @@ from pathlib import Path
 import httpx
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
+
+logger = logging.getLogger("forge-api")
 
 app = FastAPI(title="forge-api", version="0.2.0")
 
@@ -178,6 +181,7 @@ def read_last_log_entry(project_path: Path) -> dict | None:
         try:
             return json.loads(line)
         except json.JSONDecodeError:
+            logger.warning(f"Corrupted LOG.md line (skipping): {line[:200]}")
             continue
     return None
 

--- a/bot/notify_endpoint.py
+++ b/bot/notify_endpoint.py
@@ -1,10 +1,14 @@
 """Notification endpoint. Forge scripts POST here to send Telegram messages."""
 
+import logging
+
 import httpx
 from fastapi import FastAPI
 from pydantic import BaseModel
 
 from config import BOT_TOKEN, CHAT_ID
+
+logger = logging.getLogger("forge-bot.notify")
 
 notify_app = FastAPI(title="forge-bot-notify", version="0.1.0")
 
@@ -26,13 +30,13 @@ async def send_notification(req: NotifyRequest):
         resp = await client.post(url, json=payload)
 
         if resp.status_code != 200 and req.parse_mode:
-            # Retry without parse_mode (formatting may have broken it)
+            logger.warning(f"Retrying notification without parse_mode due to: {resp.status_code}")
             payload.pop("parse_mode", None)
             resp = await client.post(url, json=payload)
 
         if resp.status_code != 200:
             error = resp.text[:300]
-            print(f"NOTIFY FAILED: {resp.status_code} {error}")
+            logger.error(f"NOTIFY FAILED: {resp.status_code} {error}")
             return {"status": "failed", "error": error}
 
     return {"status": "sent"}

--- a/bot/services/claude_relay.py
+++ b/bot/services/claude_relay.py
@@ -266,7 +266,7 @@ class ClaudeCodeRelay:
                     proc.kill()
                     await proc.wait()
             except ProcessLookupError:
-                pass
+                logger.debug("Process already terminated")
 
 
 # ---- Relay Registry (in-memory, per bot process) ----

--- a/bot/services/llm.py
+++ b/bot/services/llm.py
@@ -1,8 +1,12 @@
 """Anthropic SDK wrapper for LLM-powered features. Sonnet only. No fallbacks."""
 
+import logging
+
 import anthropic
 
 from config import ANTHROPIC_API_KEY, ANTHROPIC_MODEL
+
+logger = logging.getLogger("forge-bot.llm")
 
 
 async def ask_claude(prompt: str, system: str = "", max_tokens: int = 4096) -> str:
@@ -85,6 +89,7 @@ If action is "skip", set duplicate_of to the issue number."""
         result.setdefault("comment", None)
         return result
     except json.JSONDecodeError:
+        logger.warning(f"Claude returned unparseable JSON for classify_note, defaulting to 'create ux issue'. Raw response: {text[:200]}")
         return {"action": "create", "category": "ux", "summary": note[:100], "duplicate_of": None, "comment": None}
 
 

--- a/bot/sessions.py
+++ b/bot/sessions.py
@@ -8,11 +8,14 @@ Persisted to disk as JSON.
 """
 
 import json
+import logging
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 
 from config import SESSIONS_FILE
+
+logger = logging.getLogger("forge-bot.sessions")
 
 # ---- Mode (top-level modal state) ----
 
@@ -89,7 +92,8 @@ def _load() -> dict:
     if SESSIONS_FILE.exists():
         try:
             return json.loads(SESSIONS_FILE.read_text())
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError) as e:
+            logger.error(f"Corrupted session file {SESSIONS_FILE}: {e}")
             return {}
     return {}
 

--- a/scripts/forge-e2e.sh
+++ b/scripts/forge-e2e.sh
@@ -20,6 +20,7 @@ PROJECTS_DIR="$FORGE_ROOT/projects"
 STAGES=("inception" "planning" "active" "paused" "shipped")
 NEXUS_PROJECTS="$HOME/nexus/projects"
 NEXUS_WEBAPPS="$HOME/nexus/web-apps"
+STALE_ARTIFACTS=false
 
 # Crash handler — no silent failures
 # Only triggers for unexpected errors, not Playwright test failures (those are handled below)
@@ -91,7 +92,8 @@ echo ""
 # --- Clean previous artifacts (preserve directory inode for Docker bind mount) ---
 mkdir -p "$ARTIFACTS_DIR"
 if ! rm -rf "${ARTIFACTS_DIR:?}"/* "${ARTIFACTS_DIR}"/.[!.]* 2>&1; then
-    echo "WARNING: Failed to clean previous artifacts — results may include stale data" >&2
+    echo "ERROR: Failed to clean previous artifacts — results may include stale data" >&2
+    STALE_ARTIFACTS=true
 fi
 
 # --- Run Playwright ---
@@ -126,6 +128,9 @@ else
 fi
 
 echo ""
+if [[ "$STALE_ARTIFACTS" == "true" ]]; then
+    echo "NOTE: Stale artifacts were not cleaned before this run — results may have been contaminated." >&2
+fi
 echo "=== forge-e2e: done ==="
 
 exit $E2E_EXIT


### PR DESCRIPTION
## Summary

- **Logging hygiene**: Replaced `print()` with `logger.error()` in notify_endpoint. Added logging for corrupted session files, LLM JSON parse failures, corrupted LOG.md lines, and process cleanup.
- **Stale artifacts**: forge-e2e.sh now flags when stale artifacts may contaminate test results.
- **Agent mandate**: All 7 AGENT.md files now include an explicit "Error Handling — Mandatory" section requiring agents to surface all errors, never suppress silently, and log to ERRORS.md.

## Test plan

- [ ] Corrupt sessions.json, restart forge-bot — verify error logged
- [ ] Send notification with bad formatting — verify warning logged on retry
- [ ] Review AGENT.md files — verify error handling section present

🤖 Generated with [Claude Code](https://claude.com/claude-code)